### PR TITLE
Fix Missing CORS Headers in Exception Handler Responses

### DIFF
--- a/src/Middleware/CORS.php
+++ b/src/Middleware/CORS.php
@@ -191,7 +191,7 @@
 			return $this->maxAge;
 		}
 
-		protected function addCORSHeaders(Request $request, ResponseInterface $response): ResponseInterface {
+		public function addCORSHeaders(Request $request, ResponseInterface $response): ResponseInterface {
 			$serverParams = $request->getServerParams();
 
 			if ($this->isOriginAllowed('*')) {

--- a/src/SlimInit.php
+++ b/src/SlimInit.php
@@ -510,6 +510,11 @@
 				// Go!
 				$response = $handler->handle($request, $exception, $displayErrorDetails);
 
+				// Add CORS headers
+				if ($scope->corsMiddleware) {
+					$response = $scope->corsMiddleware->addCORSHeaders($request, $response);
+				}
+
 				if ($response->getStatusCode() >= 500) {
 					// Run exception callbacks
 					foreach ($scope->exceptionCallbacks as $callback) {


### PR DESCRIPTION
Manually adding CORS headers to responses returned from custom exception handlers, as middleware isn't executed.